### PR TITLE
fix: Use int value directly for sort parameter

### DIFF
--- a/tap_google_play/streams.py
+++ b/tap_google_play/streams.py
@@ -47,7 +47,7 @@ class ReviewsStream(GooglePlayStream):
                     app_id,
                     lang="en",
                     country="us",
-                    sort=Sort.NEWEST.value,
+                    sort=int(Sort.NEWEST),
                     count=1000,
                     continuation_token=continuation_token,
                 )


### PR DESCRIPTION
Fixes

```
AttributeError: 'int' object has no attribute 'value'
```

cc @pnadolny13 